### PR TITLE
Added 'n' param to fetch_articles method

### DIFF
--- a/inoreader/client.py
+++ b/inoreader/client.py
@@ -172,14 +172,14 @@ class InoreaderClient(object):
         else:
             return response["items"], None
 
-    def fetch_articles(self, folder=None, tags=None, unread=True, starred=False, limit=None):
+    def fetch_articles(self, folder=None, tags=None, unread=True, starred=False, limit=None, n=50):
         self.check_token()
 
         url = urljoin(BASE_URL, self.STREAM_CONTENTS_PATH)
         if folder:
             url = urljoin(url, quote_plus(self.GENERAL_TAG_TEMPLATE.format(folder)))
 
-        params = {"c": str(uuid4())}
+        params = {"n": n, "c": str(uuid4())}
         if unread:
             params["xt"] = self.READ_TAG
 


### PR DESCRIPTION
Adding n param to fetch_articles method in order to include in request to stream/contents/[streamId] endpoint. This will be helpful to users who want to increase the number of items returned in order to preserve total API requests and not reach limit too early. Default is 20 returned items if 'n' parameter is not specified in request so would like the ability to set this based on user preference.